### PR TITLE
Initial commit of `project_task_line` for 11.0

### DIFF
--- a/project_task_line/__init__.py
+++ b/project_task_line/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/project_task_line/__manifest__.py
+++ b/project_task_line/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    'name': 'Project Task Lines',
+    'version': '11.0.1.0.0',
+    'author': 'Hibou Corp. <hello@hibou.io>',
+    'website': 'https://hibou.io/',
+    'license': 'AGPL-3',
+    'category': 'Tools',
+    'complexity': 'easy',
+    'description': """
+Adds "todo" lines onto Project Tasks, and improves sub-tasks.
+    """,
+    'depends': [
+        'project',
+    ],
+    'data': [
+        'views/project_views.xml',
+    ],
+    'installable': True,
+    'auto_install': False,
+}

--- a/project_task_line/models/__init__.py
+++ b/project_task_line/models/__init__.py
@@ -1,0 +1,1 @@
+from . import project

--- a/project_task_line/models/project.py
+++ b/project_task_line/models/project.py
@@ -1,0 +1,39 @@
+from odoo import api, fields, models
+
+
+class ProjectTask(models.Model):
+    _inherit = 'project.task'
+
+    line_ids = fields.One2many('project.task.line', 'task_id', string='Todo List')
+    subtask_count_done = fields.Integer(compute='_compute_subtask_count', string="Sub-task Done count")
+
+    @api.multi
+    def _compute_subtask_count(self):
+        for task in self:
+            task.subtask_count = self.search_count([('id', 'child_of', task.id), ('id', '!=', task.id)])
+            task.subtask_count_done = self.search_count([('id', 'child_of', task.id), ('id', '!=', task.id), ('stage_id.fold', '=', True)])
+
+
+class ProjectTaskLine(models.Model):
+    _name = 'project.task.line'
+    _description = 'Task Todos'
+    _order = 'sequence, id desc'
+
+    task_id = fields.Many2one('project.task', required=True)
+    name = fields.Char(string='Name')
+    user_id = fields.Many2one('res.users', string='User')
+    sequence = fields.Integer(string='Sequence')
+    kanban_state = fields.Selection([
+        ('normal', 'Grey'),
+        ('done', 'Green'),
+        ('blocked', 'Red')], string='Kanban State',
+        copy=False, default='normal', required=True,
+        help="A task's kanban state indicates special situations affecting it:\n"
+             " * Grey is the default situation\n"
+             " * Red indicates something is preventing the progress of this task\n"
+             " * Green indicates the task is complete")
+
+    @api.onchange('kanban_state')
+    def _onchange_kanban_state(self):
+        if self.kanban_state == 'done':
+            self.user_id = self.env.user

--- a/project_task_line/views/project_views.xml
+++ b/project_task_line/views/project_views.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <!--<record id="edit_project_inherit" model="ir.ui.view">-->
+        <!--<field name="name">project.project.form.inherit</field>-->
+        <!--<field name="model">project.project</field>-->
+        <!--<field name="inherit_id" ref="project.edit_project" />-->
+        <!--<field name="arch" type="xml">-->
+            <!--<xpath expr="//notebook" position="inside">-->
+                <!--<page name="note_page" string="Notes">-->
+                    <!--<field name="note" nolabel="1" type="html"/>-->
+                    <!--<div class="oe_clear"/>-->
+                <!--</page>-->
+            <!--</xpath>-->
+        <!--</field>-->
+    <!--</record>-->
+
+    <record id="view_task_form2_inherit" model="ir.ui.view">
+        <field name="name">project.task.form.inherit</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.view_task_form2" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='subtask_count']" position="replace">
+                <div class="o_field_widget o_stat_info">
+                    <span class="o_stat_value"><field name="subtask_count_done" widget="statinfo" nolabel="1"/> / <field name="subtask_count" widget="statinfo" nolabel="1"/></span>
+                    <span class="o_stat_text">Sub-Tasks</span>
+                </div>
+            </xpath>
+            <xpath expr="//page[@name='description_page']" position="after">
+                <page name="task_lines" string="Todo List">
+                    <field name="line_ids" widget="one2many_list">
+                        <tree editable="bottom">
+                            <field name="sequence" widget="handle"/>
+                            <field name="name"/>
+                            <field name="kanban_state" widget="state_selection" string="Status"/>
+                            <field name="user_id" string="Completed by" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Simple module that does two simple things.

1. Adds a "done" count for subtasks.  Quickly see what portion of subtasks are completed/folded.
2. Adds simple 'todo' list on tasks.  Think things that need to be done and tracked, but not necessarily needing a whole task to accomplish.  (e.g. maybe the task is assigned to a you, and you need to keep track of the task in a couple of steps. (get credentials, backup, deploy)