### PR TITLE
Add the content type to files stored in minio

### DIFF
--- a/attachment_minio/models/ir_attachment.py
+++ b/attachment_minio/models/ir_attachment.py
@@ -85,7 +85,10 @@ class MinioAttachment(models.Model):
             client = self._get_minio_client()
             bucket = self._get_minio_bucket(client)
             minio_key = self._get_minio_key(key)
-            client.put_object(bucket, minio_key, io.BytesIO(bin_data), len(bin_data))
+            client.put_object(
+                bucket, minio_key, io.BytesIO(bin_data), len(bin_data),
+                content_type=self.mimetype,
+            )
             return self._get_minio_fname(bucket, minio_key)
         return super(MinioAttachment, self)._store_file_write(key, bin_data)
 


### PR DESCRIPTION
Hi, the module works very well except for this detail.

Before this commit, an error is raised in google-chrome when opening Odoo.

The mime type octet-stream is not a valid stylesheet mimetype.

![image](https://user-images.githubusercontent.com/27902736/82842060-42298b00-9ea6-11ea-9923-0244576f3f5f.png)
